### PR TITLE
Replace uses of std::ptr_fun() which has been removed from C++17

### DIFF
--- a/external/OpenMesh/Core/IO/reader/BaseReader.hh
+++ b/external/OpenMesh/Core/IO/reader/BaseReader.hh
@@ -156,7 +156,8 @@ protected:
  * @return trimmed string
  */
 static inline std::string &left_trim(std::string &_string) {
-  _string.erase(_string.begin(), std::find_if(_string.begin(), _string.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
+  _string.erase(_string.begin(), std::find_if(_string.begin(), _string.end(),
+                                              [](int ch) { return !std::isspace(ch); }));
   return _string;
 }
 
@@ -168,7 +169,8 @@ static inline std::string &left_trim(std::string &_string) {
  * @return trimmed string
  */
 static inline std::string &right_trim(std::string &_string) {
-  _string.erase(std::find_if(_string.rbegin(), _string.rend(), std::not1(std::ptr_fun<int, int>(std::isspace))).base(), _string.end());
+  _string.erase(std::find_if(_string.rbegin(), _string.rend(),
+                             [](int ch) { return !std::isspace(ch); }).base(), _string.end());
   return _string;
 }
 


### PR DESCRIPTION
This fixes build on C++17 on compilers that strictly follow the standard.